### PR TITLE
add seaborn to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ sphinx
 numpydoc
 flake8
 pytest
+seaborn


### PR DESCRIPTION
'seaborn' should be added to requirements.txt in order for command "pytest -v" to be successfully executed (else returns an 'import error' message). thank you ! :^)